### PR TITLE
🔒 Fix path traversal vulnerability in ZIP archive creation

### DIFF
--- a/bakzip/services/zip_service.py
+++ b/bakzip/services/zip_service.py
@@ -31,12 +31,23 @@ def create_zip(files, output, password=None, compression='normal'):
             zip_file.setpassword(password.encode())
             zip_file.setencryption(pyzipper.WZ_AES)
 
+        if not files:
+            return
+
+        base_dir = os.path.dirname(files[0])
         for file in tqdm(files, desc="Zipping files", unit="file"):
-            arcname = os.path.relpath(file, os.path.dirname(files[0]))
+            arcname = os.path.relpath(file, base_dir)
+
+            # Security check: prevent path traversal by ensuring arcname
+            # is relative and stays within the intended archive structure.
+            if os.path.isabs(arcname) or ".." in arcname.split(os.path.sep):
+                print(f"Skipping {file}: potential path traversal in archive name '{arcname}'")
+                continue
+
             try:
                 zip_file.write(file, arcname)
             except OSError as e:
-                print(f"Error adding {file} to tar file: {e}")
+                print(f"Error adding {file} to ZIP file: {e}")
 
 if __name__ == "__main__":
     create_zip(["test.txt"], "test.zip", "password", "normal")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,60 @@
+import os
+import shutil
+import sys
+from unittest.mock import MagicMock
+
+# Mock pyzipper before importing zip_service
+mock_pyzipper = MagicMock()
+sys.modules['pyzipper'] = mock_pyzipper
+mock_tqdm = MagicMock()
+sys.modules['tqdm'] = mock_tqdm
+
+from bakzip.services.zip_service import create_zip
+
+def test_zip_path_traversal_protection(tmpdir):
+    # Setup
+    test_dir = tmpdir.mkdir("base_dir")
+    test_file = test_dir.join("test.txt")
+    test_file.write("content")
+
+    # File outside the base directory
+    outside_dir = tmpdir.mkdir("outside_dir")
+    outside_file = outside_dir.join("outside.txt")
+    outside_file.write("outside content")
+
+    files = [str(test_file), str(outside_file)]
+    output_zip = str(tmpdir.join("output.zip"))
+
+    # Configure mock
+    mock_zip_instance = mock_pyzipper.AESZipFile.return_value.__enter__.return_value
+
+    # Run the function
+    create_zip(files, output_zip)
+
+    # Verify that zip_file.write was called for test.txt but NOT for outside.txt
+    # arcname for test.txt should be "test.txt"
+    # arcname for outside.txt would be "../outside_dir/outside.txt"
+
+    called_arcnames = [call.args[1] for call in mock_zip_instance.write.call_args_list]
+
+    assert "test.txt" in called_arcnames
+    assert not any(".." in name for name in called_arcnames)
+    assert not any(os.path.isabs(name) for name in called_arcnames)
+
+    print("Security test verified with mocks.")
+
+if __name__ == "__main__":
+    # If run directly without pytest
+    class TmpDir:
+        def mkdir(self, name):
+            d = os.path.join("/tmp", name)
+            if not os.path.exists(d): os.makedirs(d)
+            return Path(d)
+    class Path:
+        def __init__(self, p): self.p = p
+        def join(self, n): return Path(os.path.join(self.p, n))
+        def write(self, c):
+            with open(self.p, "w") as f: f.write(c)
+        def __str__(self): return self.p
+
+    test_zip_path_traversal_protection(TmpDir())


### PR DESCRIPTION
### 🔒 Security Fix: Path Traversal in ZIP Archive Creation

#### 🎯 What:
Fixed a security vulnerability in `bakzip/services/zip_service.py` where unsanitized file paths were used as entry names within the ZIP archive.

#### ⚠️ Risk:
If a user or an automated process provided a list of files that included paths outside the intended base directory, `os.path.relpath` could produce archive names containing `..` (e.g., `../../etc/passwd`). When such an archive is extracted by a vulnerable or standard ZIP utility, it could overwrite sensitive files outside the extraction directory.

#### 🛡️ Solution:
- Implemented a check using `os.path.isabs()` and `arcname.split(os.path.sep)` to identify and skip any archive entries that attempt path traversal.
- Added a unit test in `tests/test_security.py` that mocks the `pyzipper` library to verify that files attempting traversal are correctly skipped while legitimate files are preserved.
- Improved the robustness of the `create_zip` function by adding a guard against empty input lists and correcting a typo in the error logging.


---
*PR created automatically by Jules for task [15310914839169412225](https://jules.google.com/task/15310914839169412225) started by @Smx27*