### PR TITLE
🔒 [security fix] Secure password handling via interactive prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ pip install -e .
 This will install bakzip package in a way that allows you to make changes to the code and have them reflected immediately.
 Now, you can run your CLI tool from anywhere in your system by using the command 
 ```bash
-bakzip --directory /path/to/dir --output backup.zip --password mySecret123 --compression maximum --verbose
+bakzip --directory /path/to/dir --output backup.zip --password --compression maximum --verbose
 ```
 ## Usage
 Run the tool with the following command:
 ```bash
-python main.py --directory /path/to/dir --output backup.zip --password mySecret123 --compression maximum --verbose
+python main.py --directory /path/to/dir --output backup.zip --password --compression maximum --verbose
 ```
 
 ## Arguments:
 - --directory: The directory to be backed up (default: current directory).
 - --output: The name of the output backup file (default: backup_<directory_name>.<format>).
-- --password: The password to protect the backup file (optional).
+- --password: The password to protect the backup file (optional). If used without a value, you will be prompted securely.
 - --compression: The compression level (choices: fast, normal, maximum; default: normal).
 - --encryption: The encryption algorithm (choices: none, aes, rsa; default: none).
 - --format: The backup format (choices: zip, tar, gz; default: zip).
@@ -62,7 +62,7 @@ python main.py --directory /path/to/dir --output backup.zip --password mySecret1
 
 ### Example
 ```bash
-bakzip --directory /path/to/dir --output backup.zip --password mySecret123 --compression maximum --encryption aes --format zip --verbose
+bakzip --directory /path/to/dir --output backup.zip --password --compression maximum --encryption aes --format zip --verbose
 ```
 
 ### Notes

--- a/bakzip/main.py
+++ b/bakzip/main.py
@@ -11,6 +11,7 @@ This module handles the core logic of the BakZIP CLI application, including:
 import os
 import time
 import traceback
+import getpass
 import pyfiglet
 from bakzip.utilities.command_line_options import parse_arguments
 from bakzip.services.directory_processor import process_directory
@@ -35,6 +36,9 @@ def main():
     print(result)
     print('by @smx27 Github: @smx27')
     args = parse_arguments()
+    password = args.password
+    if password is True:
+        password = getpass.getpass("Enter password to protect the backup file: ")
     directory = args.directory
     output = args.output or f'backup_{os.path.basename(directory)}'
     if args.format == 'zip':
@@ -45,7 +49,6 @@ def main():
             output += '.gz'
     else:
         raise ValueError("Unsupported format")
-    password = args.password
     compression = args.compression
     verbose = args.verbose
     log_file_path = os.path.join(os.path.dirname(output), 'bakzip.log')

--- a/bakzip/utilities/command_line_options.py
+++ b/bakzip/utilities/command_line_options.py
@@ -4,7 +4,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='BakZip - A CLI tool to backup directories, excluding specified files and folders.')
     parser.add_argument('-d','--directory', type=str, help='The directory to be backed up', default='.')
     parser.add_argument('-o','--output', type=str, help='The name of the output backup file', default='default')
-    parser.add_argument('-p','--password', type=str, help='The password to protect the backup file', default=None)
+    parser.add_argument('-p','--password', nargs='?', const=True, help='The password to protect the backup file. If used without a value, you will be prompted.', default=None)
     parser.add_argument('-c','--compression', type=str, choices=['fast', 'normal', 'maximum', 'gz'], help='The compression level', default='normal')
     parser.add_argument('-e','--encryption', type=str, choices=['none', 'aes', 'rsa'], help='The encryption algorithm', default='none')
     parser.add_argument('-f','--format', type=str, choices=['zip', 'tar', 'gz'], help='The backup format', default='zip')


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Password passed via command line arguments.

### ⚠️ Risk: The potential impact if left unfixed
Passing passwords as command-line arguments exposes them to other users on the system via process listings (e.g., `ps aux`) and saves them in the user's shell history file (e.g., `.bash_history`), which could lead to unauthorized access to the backup files.

### 🛡️ Solution: How the fix addresses the vulnerability
I have modified the CLI to support an interactive password prompt. Users can now use the `-p` or `--password` flag without providing a value. When this flag is detected, BakZip will securely prompt the user for their password using the `getpass` library, ensuring the password is not echoed to the terminal, not stored in history, and not visible in process lists. Backward compatibility is maintained for automated scripts, although interactive use is now the recommended and safer approach.

---
*PR created automatically by Jules for task [11824525639763594348](https://jules.google.com/task/11824525639763594348) started by @Smx27*