### PR TITLE
⚡ Optimize directory processing by reducing redundant getsize calls

### DIFF
--- a/bakzip/services/directory_processor.py
+++ b/bakzip/services/directory_processor.py
@@ -83,12 +83,12 @@ def process_directory(directory, log_file_path):
             for file in files:
                 file_path = os.path.join(root, file)
                 rel_path = os.path.relpath(file_path, directory)
-                file_size = os.path.getsize(file_path)
                 if not should_ignore(rel_path, ignore_list):
                     files_to_include.append(file_path)
                 else:
+                    file_size = os.path.getsize(file_path)
                     skipped_files.append(file_path)
-                    total_skipped_size += os.path.getsize(file_path)
+                    total_skipped_size += file_size
                     log_file.write(f"Skipped: {file_path} Size: {file_size} \n")
             log_file.write(f"Processed directory: {root} \n")
     return files_to_include, skipped_files, total_skipped_size


### PR DESCRIPTION
Optimized the file processing loop in `bakzip/services/directory_processor.py` by:
1. Moving `os.path.getsize(file_path)` inside the `else` block so it is only executed for ignored files.
2. Reusing the `file_size` variable when updating `total_skipped_size`, avoiding a second `os.path.getsize` call for the same file.

These changes eliminate unnecessary synchronous I/O operations, making the directory processing more efficient, especially when many files are included in the backup. Verified the optimization with a benchmark and ensured no regressions with existing tests.

---
*PR created automatically by Jules for task [672000598674427821](https://jules.google.com/task/672000598674427821) started by @Smx27*