### PR TITLE
🧪 Add unit tests for should_ignore in directory_processor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock missing dependencies
+mock_pyfiglet = MagicMock()
+sys.modules["pyfiglet"] = mock_pyfiglet
+
+mock_pyzipper = MagicMock()
+mock_pyzipper.ZIP_LZMA = 1
+mock_pyzipper.ZIP_DEFLATED = 2
+mock_pyzipper.ZIP_BZIP2 = 3
+sys.modules["pyzipper"] = mock_pyzipper
+
+mock_tqdm_mod = MagicMock()
+sys.modules["tqdm"] = mock_tqdm_mod
+mock_tqdm_mod.tqdm = MagicMock()

--- a/tests/test_directory_processor.py
+++ b/tests/test_directory_processor.py
@@ -1,0 +1,31 @@
+from bakzip.services.directory_processor import should_ignore
+
+def test_should_ignore_exact_match():
+    ignore_list = ["file.txt"]
+    assert should_ignore("file.txt", ignore_list) is True
+    assert should_ignore("other.txt", ignore_list) is False
+
+def test_should_ignore_wildcard_match():
+    ignore_list = ["*.tmp"]
+    assert should_ignore("test.tmp", ignore_list) is True
+    assert should_ignore("test.txt", ignore_list) is False
+
+def test_should_ignore_subdirectory_wildcard():
+    ignore_list = ["temp_*"]
+    assert should_ignore("temp_data/file.txt", ignore_list) is True
+    assert should_ignore("data/temp_file.txt", ignore_list) is False
+
+def test_should_ignore_empty_list():
+    ignore_list = []
+    assert should_ignore("any_file.txt", ignore_list) is False
+
+def test_should_ignore_path_in_subdirectory():
+    ignore_list = ["sub/*.log"]
+    assert should_ignore("sub/test.log", ignore_list) is True
+    assert should_ignore("test.log", ignore_list) is False
+
+def test_should_ignore_multiple_patterns():
+    ignore_list = ["*.pyc", "__pycache__"]
+    assert should_ignore("main.pyc", ignore_list) is True
+    assert should_ignore("__pycache__", ignore_list) is True
+    assert should_ignore("main.py", ignore_list) is False


### PR DESCRIPTION
Added unit tests for `should_ignore` in `bakzip/services/directory_processor.py`.
Included a `conftest.py` to mock dependencies that were hindering test execution.
Verified that tests pass and fail correctly when the logic is modified.

---
*PR created automatically by Jules for task [18256601099534311860](https://jules.google.com/task/18256601099534311860) started by @Smx27*