### PR TITLE
🧹 Clean up duplicated imports in bakzip/__init__.py

### DIFF
--- a/bakzip/__init__.py
+++ b/bakzip/__init__.py
@@ -15,7 +15,5 @@ Usage:
 from .main import main
 from .utilities.command_line_options import parse_arguments
 from .services.directory_processor import get_ignore_list, should_ignore, process_directory
-from .services.process_directory import process_directory,get_ignore_list,should_ignore
 from .services.tar_service import create_tar
 from .services.zip_service import create_zip
-from .config.bakzipignore import process_directory,get_ignore_list,should_ignore


### PR DESCRIPTION
This PR addresses a code health issue where several functions were being imported multiple times from different submodules into the `bakzip` package namespace.

🎯 **What:** Removed redundant imports of `process_directory`, `get_ignore_list`, and `should_ignore` in `bakzip/__init__.py`.
💡 **Why:** This cleans up the package namespace, improves readability, and makes the codebase more maintainable by having a single source of truth for these exported functions.
✅ **Verification:** Verified that the functions remain accessible via the `bakzip` package and that existing tests pass (using temporary mocks for missing environment dependencies which were cleaned up before submission).
✨ **Result:** A cleaner and more concise `bakzip/__init__.py` file.

---
*PR created automatically by Jules for task [9232443630652386361](https://jules.google.com/task/9232443630652386361) started by @Smx27*