### PR TITLE
🔒 Fix sensitive data exposure via traceback logging

### DIFF
--- a/bakzip/main.py
+++ b/bakzip/main.py
@@ -88,7 +88,14 @@ def main():
     except Exception as ex:
         print(f'An error occurred: {ex}')
         if verbose:
-            print(traceback.format_exc())
+            # Log the traceback to the log file instead of printing it to stdout
+            try:
+                with open(log_file_path, 'a', encoding='utf-8') as log_file:
+                    log_file.write(f"\nAn error occurred during the backup process: {ex}\n")
+                    log_file.write(traceback.format_exc())
+                print(f'Full traceback has been logged to: {log_file_path}')
+            except Exception as log_err:
+                print(f'Failed to log traceback to {log_file_path}: {log_err}')
 
 if __name__ == '__main__':
     main()

--- a/bakzip/services/zip_service.py
+++ b/bakzip/services/zip_service.py
@@ -44,7 +44,7 @@ def create_zip(files, output, password=None, compression='normal', base_dir=None
             try:
                 zip_file.write(file, arcname)
             except OSError as e:
-                print(f"Error adding {file} to tar file: {e}")
+                print(f"Error adding {file} to zip file: {e}")
 
 if __name__ == "__main__":
     create_zip(["test.txt"], "test.zip", "password", "normal")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ Test suite for the BakZip CLI.
 """
 import os
 import shutil
+from unittest.mock import MagicMock
 import pytest
 from bakzip.services.directory_processor import process_directory
 from bakzip.services.zip_service import create_zip
@@ -61,3 +62,30 @@ def test_create_tar(temp_directory):
     output_file = str(temp_directory.join("test.tar"))
     create_tar(files_to_include, output_file, 'gz', base_dir=str(temp_directory))
     assert os.path.exists(output_file)
+
+def test_no_traceback_on_error(capsys):
+    """
+    Test that no traceback is printed to stdout when an error occurs,
+    even in verbose mode.
+    """
+    from unittest.mock import patch
+    from bakzip.main import main
+
+    # Mock arguments for verbose mode
+    class MockArgs:
+        directory = '.'
+        output = 'test_output'
+        format = 'zip'
+        compression = 'normal'
+        encryption = 'none'
+        verbose = True
+        password = None
+
+    with patch("bakzip.main.parse_arguments", return_value=MockArgs()), \
+         patch("bakzip.main.process_directory", side_effect=Exception("Test Error")):
+        main()
+
+    captured = capsys.readouterr()
+    assert "An error occurred: Test Error" in captured.out
+    assert "Traceback (most recent call last):" not in captured.out
+    assert "Full traceback has been logged to:" in captured.out


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This PR addresses a sensitive data exposure vulnerability where full stack traces were printed to standard output when the `--verbose` flag was used and an error occurred.

⚠️ **Risk:** The potential impact if left unfixed
Printing full tracebacks can leak sensitive internal information, including file paths, environment variables, and internal code logic, which could be exploited by an attacker to gain deeper insights into the system's architecture and potential vulnerabilities.

🛡️ **Solution:** How the fix addresses the vulnerability
- Removed `print(traceback.format_exc())` from the standard output.
- Implemented redirection of tracebacks to a local `bakzip.log` file when verbose mode is enabled.
- Added robust error handling to the logging logic to ensure the tool fails gracefully even if the log file is unwritable.
- Added a regression test to verify that tracebacks do not appear in stdout under error conditions.
- Fixed an unrelated typo in an error message within `bakzip/services/zip_service.py`.

---
*PR created automatically by Jules for task [16165098652439797349](https://jules.google.com/task/16165098652439797349) started by @Smx27*