### PR TITLE
🧹 Fix incorrect error message and docstring in ZIP service

### DIFF
--- a/bakzip/services/zip_service.py
+++ b/bakzip/services/zip_service.py
@@ -2,7 +2,7 @@
 """
 This module provides functions for creating ZIP archives.
 
-The `#! /usr/env/bin python` function allows you to create a TAR archive from a list of files,
+The `create_zip` function allows you to create a ZIP archive from a list of files,
 with optional compression using pyzipper.
 """
 import os
@@ -44,7 +44,7 @@ def create_zip(files, output, password=None, compression='normal', base_dir=None
             try:
                 zip_file.write(file, arcname)
             except OSError as e:
-                print(f"Error adding {file} to tar file: {e}")
+                print(f"Error adding {file} to zip file: {e}")
 
 if __name__ == "__main__":
     create_zip(["test.txt"], "test.zip", "password", "normal")


### PR DESCRIPTION
This change fixes a code health issue in `bakzip/services/zip_service.py` where an error message and the module docstring incorrectly referred to TAR files instead of ZIP files.

🎯 **What:**
- Replaced "tar file" with "zip file" in the error handling logic within `create_zip`.
- Updated the module docstring to correctly describe `create_zip` and refer to ZIP archives.

💡 **Why:**
- Improves code maintainability and readability by ensuring logging and documentation are accurate and not misleading (likely due to a previous copy-paste from `tar_service.py`).

✅ **Verification:**
- Verified the changes with `read_file`.
- Ran the full test suite with `pytest`, all 16 tests passed.
- Received a positive code review confirming the correctness and thoroughness of the fix.

✨ **Result:**
- Accurate error messages and documentation for the ZIP service.

---
*PR created automatically by Jules for task [642785492042275300](https://jules.google.com/task/642785492042275300) started by @Smx27*