### PR TITLE
🔒 [Security] Prevent password exposure in process listing

### DIFF
--- a/bakzip/main.py
+++ b/bakzip/main.py
@@ -36,9 +36,11 @@ def main():
     print(result)
     print('by @smx27 Github: @smx27')
     args = parse_arguments()
-    password = args.password
-    if password is True:
-        password = getpass.getpass("Enter password to protect the backup file: ")
+    password = None
+    if args.password:
+        password = os.environ.get('BAKZIP_PASSWORD')
+        if not password:
+            password = getpass.getpass("Enter password to protect the backup file: ")
     directory = args.directory
     output = args.output or f'backup_{os.path.basename(directory)}'
     if args.format == 'zip':

--- a/bakzip/utilities/command_line_options.py
+++ b/bakzip/utilities/command_line_options.py
@@ -4,7 +4,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='BakZip - A CLI tool to backup directories, excluding specified files and folders.')
     parser.add_argument('-d','--directory', type=str, help='The directory to be backed up', default='.')
     parser.add_argument('-o','--output', type=str, help='The name of the output backup file', default='default')
-    parser.add_argument('-p','--password', nargs='?', const=True, help='The password to protect the backup file. If used without a value, you will be prompted.', default=None)
+    parser.add_argument('-p','--password', action='store_true', help='Enable password protection. If set, you will be prompted for a password or it will be read from a project-appropriate environment variable.')
     parser.add_argument('-c','--compression', type=str, choices=['fast', 'normal', 'maximum', 'gz'], help='The compression level', default='normal')
     parser.add_argument('-e','--encryption', type=str, choices=['none', 'aes', 'rsa'], help='The encryption algorithm', default='none')
     parser.add_argument('-f','--format', type=str, choices=['zip', 'tar', 'gz'], help='The backup format', default='zip')

--- a/tests/test_command_line_options.py
+++ b/tests/test_command_line_options.py
@@ -10,7 +10,7 @@ class TestCommandLineOptions(unittest.TestCase):
             args = parse_arguments()
             self.assertEqual(args.directory, '.')
             self.assertEqual(args.output, 'default')
-            self.assertIsNone(args.password)
+            self.assertFalse(args.password)
             self.assertEqual(args.compression, 'normal')
             self.assertEqual(args.encryption, 'none')
             self.assertEqual(args.format, 'zip')
@@ -22,7 +22,7 @@ class TestCommandLineOptions(unittest.TestCase):
             'bakzip',
             '--directory', '/home/user/data',
             '--output', 'my_backup',
-            '--password', 'secure_pass',
+            '--password',
             '--compression', 'maximum',
             '--encryption', 'aes',
             '--format', 'tar',
@@ -32,7 +32,7 @@ class TestCommandLineOptions(unittest.TestCase):
             args = parse_arguments()
             self.assertEqual(args.directory, '/home/user/data')
             self.assertEqual(args.output, 'my_backup')
-            self.assertEqual(args.password, 'secure_pass')
+            self.assertTrue(args.password)
             self.assertEqual(args.compression, 'maximum')
             self.assertEqual(args.encryption, 'aes')
             self.assertEqual(args.format, 'tar')
@@ -44,7 +44,7 @@ class TestCommandLineOptions(unittest.TestCase):
             'bakzip',
             '-d', './src',
             '-o', 'src_backup',
-            '-p', 'p@ss',
+            '-p',
             '-c', 'fast',
             '-e', 'rsa',
             '-f', 'gz',
@@ -54,7 +54,7 @@ class TestCommandLineOptions(unittest.TestCase):
             args = parse_arguments()
             self.assertEqual(args.directory, './src')
             self.assertEqual(args.output, 'src_backup')
-            self.assertEqual(args.password, 'p@ss')
+            self.assertTrue(args.password)
             self.assertEqual(args.compression, 'fast')
             self.assertEqual(args.encryption, 'rsa')
             self.assertEqual(args.format, 'gz')

--- a/tests/test_security_fix.py
+++ b/tests/test_security_fix.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+from bakzip.main import main
+
+class TestSecurityFix(unittest.TestCase):
+    @patch('bakzip.main.parse_arguments')
+    @patch('bakzip.main.getpass.getpass')
+    @patch('bakzip.main.pyfiglet.figlet_format', return_value='BakZIP')
+    @patch('bakzip.main.process_directory', return_value=([], [], 0))
+    @patch('bakzip.main.create_zip')
+    def test_password_from_env(self, mock_create_zip, mock_process, mock_figlet, mock_getpass, mock_parse_args):
+        """Test that password is taken from BAKZIP_PASSWORD environment variable."""
+        mock_args = MagicMock()
+        mock_args.password = True
+        mock_args.directory = '.'
+        mock_args.output = 'test'
+        mock_args.format = 'zip'
+        mock_args.compression = 'normal'
+        mock_args.encryption = 'none'
+        mock_args.verbose = False
+        mock_parse_args.return_value = mock_args
+
+        with patch.dict(os.environ, {'BAKZIP_PASSWORD': 'env_password'}):
+            main()
+            mock_getpass.assert_not_called()
+            # The password is the 3rd argument to create_zip
+            mock_create_zip.assert_called_once()
+            args, kwargs = mock_create_zip.call_args
+            self.assertEqual(args[2], 'env_password')
+
+    @patch('bakzip.main.parse_arguments')
+    @patch('bakzip.main.getpass.getpass')
+    @patch('bakzip.main.pyfiglet.figlet_format', return_value='BakZIP')
+    @patch('bakzip.main.process_directory', return_value=([], [], 0))
+    @patch('bakzip.main.create_zip')
+    def test_password_from_prompt(self, mock_create_zip, mock_process, mock_figlet, mock_getpass, mock_parse_args):
+        """Test that user is prompted if BAKZIP_PASSWORD is not set."""
+        mock_args = MagicMock()
+        mock_args.password = True
+        mock_args.directory = '.'
+        mock_args.output = 'test'
+        mock_args.format = 'zip'
+        mock_args.compression = 'normal'
+        mock_args.encryption = 'none'
+        mock_args.verbose = False
+        mock_parse_args.return_value = mock_args
+        mock_getpass.return_value = 'prompt_password'
+
+        with patch.dict(os.environ, {}, clear=True):
+            main()
+            mock_getpass.assert_called_once()
+            mock_create_zip.assert_called_once()
+            args, kwargs = mock_create_zip.call_args
+            self.assertEqual(args[2], 'prompt_password')
+
+    @patch('bakzip.main.parse_arguments')
+    @patch('bakzip.main.getpass.getpass')
+    @patch('bakzip.main.pyfiglet.figlet_format', return_value='BakZIP')
+    @patch('bakzip.main.process_directory', return_value=([], [], 0))
+    @patch('bakzip.main.create_zip')
+    def test_no_password_flag(self, mock_create_zip, mock_process, mock_figlet, mock_getpass, mock_parse_args):
+        """Test that no password is used if the flag is not provided."""
+        mock_args = MagicMock()
+        mock_args.password = False
+        mock_args.directory = '.'
+        mock_args.output = 'test'
+        mock_args.format = 'zip'
+        mock_args.compression = 'normal'
+        mock_args.encryption = 'none'
+        mock_args.verbose = False
+        mock_parse_args.return_value = mock_args
+
+        with patch.dict(os.environ, {'BAKZIP_PASSWORD': 'env_password'}):
+            main()
+            mock_getpass.assert_not_called()
+            mock_create_zip.assert_called_once()
+            args, kwargs = mock_create_zip.call_args
+            self.assertIsNone(args[2])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `-p`/`--password` argument in the `bakzip` tool previously allowed users to provide a password directly as a command-line argument value. This is insecure as the password remains visible in process listings to any user on the same machine.

This PR fixes the vulnerability by:
1.  **Removing direct password input:** The `--password` flag no longer accepts a value. It now acts as a boolean switch to enable password protection.
2.  **Implementing secure password retrieval:** When the `--password` flag is used, the application now:
    -   Attempts to read the password from the `BAKZIP_PASSWORD` environment variable.
    -   Prompts the user interactively using `getpass.getpass()` if the environment variable is not set.

This ensures that passwords are never passed as command-line arguments while still providing a way for automated tools (via environment variables) and interactive users to specify a password securely.

Verified with new and updated unit tests.

---
*PR created automatically by Jules for task [7484661332417233459](https://jules.google.com/task/7484661332417233459) started by @Smx27*