### PR TITLE
🧹 Remove hardcoded path for .bakzipignore

### DIFF
--- a/bakzip/services/directory_processor.py
+++ b/bakzip/services/directory_processor.py
@@ -23,7 +23,7 @@ def _get_compiled_regex(ignore_list_tuple):
     return re.compile('|'.join(regex_patterns))
 
 
-def get_ignore_list():
+def get_ignore_list(directory):
     """
     Returns a list of ignore patterns from a .bakzipignore file.
 
@@ -34,7 +34,7 @@ def get_ignore_list():
         A list of ignore patterns.
     """
     ignore_list = []
-    ignore_file = './.bakzipignore'
+    ignore_file = os.path.join(directory, '.bakzipignore')
     if os.path.exists(ignore_file):
         with open(ignore_file, 'r', encoding='utf-8') as f:
             for line in f:
@@ -91,7 +91,7 @@ def process_directory(directory, log_file_path, verbose=False):
             - A list of skipped files.
             - The total size of skipped files (calculated only if verbose is True).
     """
-    ignore_list = tuple(get_ignore_list())
+    ignore_list = tuple(get_ignore_list(directory))
     files_to_include = []
     skipped_files = []
     total_skipped_size = 0

--- a/tests/test_get_ignore_list_path.py
+++ b/tests/test_get_ignore_list_path.py
@@ -1,0 +1,24 @@
+import os
+from bakzip.services.directory_processor import get_ignore_list
+
+def test_get_ignore_list_from_specified_directory(tmpdir):
+    # Create a target directory
+    target_dir = tmpdir.mkdir("target")
+    ignore_file = target_dir.join(".bakzipignore")
+    ignore_file.write("*.log\n# comment\nsecret.txt")
+
+    # Now get_ignore_list should take directory as an argument
+    # and use it to find '.bakzipignore'.
+    patterns = get_ignore_list(str(target_dir))
+
+    # It should correctly parse the patterns
+    assert "secret.txt" in patterns
+    assert "*.log" in patterns
+    assert "# comment" not in patterns
+    assert len(patterns) >= 2 # plus some auto-generated ones for directories/wildcards
+
+def test_get_ignore_list_no_file(tmpdir):
+    # If the file doesn't exist, it should return an empty list
+    target_dir = tmpdir.mkdir("empty")
+    patterns = get_ignore_list(str(target_dir))
+    assert patterns == []


### PR DESCRIPTION
🎯 **What:** This PR fixes a code health issue where the `.bakzipignore` file path was hardcoded to `./.bakzipignore`. It refactors `get_ignore_list` to accept a `directory` argument and uses `os.path.join(directory, '.bakzipignore')` to locate the file.

💡 **Why:** Hardcoding the path to the current working directory made the tool behave incorrectly when executed from a different directory than the one being backed up. Aligning the implementation with its docstring (which already mentioned a directory argument) improves maintainability and correctness.

✅ **Verification:** 
- Created a reproduction test case in `tests/test_get_ignore_list_path.py` which confirmed the fix.
- Ran the full test suite (`pytest tests/`), and all 27 tests passed.
- Verified that existing mocks in `tests/test_directory_processor.py` continue to work with the updated signature.

✨ **Result:** The `.bakzipignore` file is now correctly resolved relative to the target backup directory.

---
*PR created automatically by Jules for task [5222831846736803593](https://jules.google.com/task/5222831846736803593) started by @Smx27*