### PR TITLE
🔒 [security] Fix backup archives created with default permissions

### DIFF
--- a/bakzip/main.py
+++ b/bakzip/main.py
@@ -32,6 +32,9 @@ def main():
         ValueError: If an unsupported format is specified.
         Exception: If any other error occurs during the backup process.
     """
+    # Set restrictive umask (0o077) to ensure all created files (archives and logs)
+    # have restrictive permissions (0o600 for files, 0o700 for directories).
+    os.umask(0o077)
     result = pyfiglet.figlet_format("BakZIP", font = "slant")
     print(result)
     print('by @smx27 Github: @smx27')

--- a/tests/test_security_permissions.py
+++ b/tests/test_security_permissions.py
@@ -1,0 +1,65 @@
+import os
+import stat
+import pytest
+from unittest.mock import patch, MagicMock
+from bakzip.main import main
+
+def test_archive_permissions(tmp_path):
+    """
+    Test that the created archive has restrictive permissions (0o600).
+    """
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+    test_file = test_dir / "test.txt"
+    test_file.write_text("test content")
+
+    output_tar = tmp_path / "backup.tar"
+
+    # Mock arguments for the main function
+    class MockArgs:
+        directory = str(test_dir)
+        output = str(output_tar).replace(".tar", "") # main adds .tar
+        format = 'tar'
+        compression = None
+        encryption = 'none'
+        verbose = False
+        password = None
+
+    # We need to ensure output_tar includes the extension as main() would add it
+    final_output = str(output_tar)
+
+    with patch("bakzip.main.parse_arguments", return_value=MockArgs()), \
+         patch("bakzip.main.pyfiglet.figlet_format", return_value="BakZIP"):
+        main()
+
+    assert os.path.exists(final_output)
+    mode = os.stat(final_output).st_mode
+    # 0o600 means read/write for owner only
+    assert (mode & 0o777) == 0o600
+
+def test_log_file_permissions(tmp_path):
+    """
+    Test that the log file created in verbose mode has restrictive permissions (0o600).
+    """
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    output_tar = tmp_path / "backup.tar"
+    log_file = tmp_path / "bakzip.log"
+
+    class MockArgs:
+        directory = str(test_dir)
+        output = str(output_tar).replace(".tar", "")
+        format = 'tar'
+        compression = None
+        encryption = 'none'
+        verbose = True
+        password = None
+
+    with patch("bakzip.main.parse_arguments", return_value=MockArgs()), \
+         patch("bakzip.main.pyfiglet.figlet_format", return_value="BakZIP"):
+        main()
+
+    assert os.path.exists(log_file)
+    mode = os.stat(log_file).st_mode
+    assert (mode & 0o777) == 0o600


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The application previously created backup archives and log files with default system permissions (often 0o664 or 0o644), which allowed other users on the same system to read potentially sensitive backup data or technical log information.

### ⚠️ Risk: The potential impact if left unfixed
On multi-user systems, unauthorized users could access the contents of the backup archives, potentially exposing sensitive files, passwords (if stored in files), or other private data.

### 🛡️ Solution: How the fix addresses the vulnerability
By calling `os.umask(0o077)` at the start of the `main()` function, the application ensures that any files it creates during its execution (including the backup archive and `bakzip.log`) will have restrictive permissions by default (owner-read/write only, or 0o600). This is a robust, process-wide mitigation that covers all file output from the tool.


---
*PR created automatically by Jules for task [10837598721893056454](https://jules.google.com/task/10837598721893056454) started by @Smx27*