### PR TITLE
🔒 [security fix] Fix hardcoded relative path for .bakzipignore

### DIFF
--- a/bakzip/services/directory_processor.py
+++ b/bakzip/services/directory_processor.py
@@ -23,7 +23,7 @@ def _get_compiled_regex(ignore_list_tuple):
     return re.compile('|'.join(regex_patterns))
 
 
-def get_ignore_list():
+def get_ignore_list(directory):
     """
     Returns a list of ignore patterns from a .bakzipignore file.
 
@@ -34,7 +34,7 @@ def get_ignore_list():
         A list of ignore patterns.
     """
     ignore_list = []
-    ignore_file = './.bakzipignore'
+    ignore_file = os.path.join(directory, '.bakzipignore')
     if os.path.exists(ignore_file):
         with open(ignore_file, 'r', encoding='utf-8') as f:
             for line in f:
@@ -91,7 +91,7 @@ def process_directory(directory, log_file_path, verbose=False):
             - A list of skipped files.
             - The total size of skipped files (calculated only if verbose is True).
     """
-    ignore_list = tuple(get_ignore_list())
+    ignore_list = tuple(get_ignore_list(directory))
     files_to_include = []
     skipped_files = []
     total_skipped_size = 0

--- a/tests/test_get_ignore_list_path.py
+++ b/tests/test_get_ignore_list_path.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+from bakzip.services.directory_processor import get_ignore_list
+
+def test_get_ignore_list_with_directory(tmp_path):
+    # Create a directory and a .bakzipignore inside it
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    ignore_file = target_dir / ".bakzipignore"
+    ignore_file.write_text("ignored_pattern")
+
+    # Now it should find it when passing the directory
+    patterns = get_ignore_list(str(target_dir))
+    assert "ignored_pattern" in patterns
+
+def test_get_ignore_list_wrong_directory(tmp_path):
+    # Create a directory and a .bakzipignore inside it
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    ignore_file = target_dir / ".bakzipignore"
+    ignore_file.write_text("ignored_pattern")
+
+    # It should NOT find it when passing a different directory
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    patterns = get_ignore_list(str(other_dir))
+    assert "ignored_pattern" not in patterns


### PR DESCRIPTION
🎯 **What:** Fixed a vulnerability where the `.bakzipignore` file was always searched for in the current working directory (`./.bakzipignore`) instead of the directory being backed up.

⚠️ **Risk:** If the application was run from a different directory than the target backup directory, it would fail to find and apply exclusion rules. This could lead to the accidental inclusion of sensitive files (like credentials or private keys) or extremely large directories that should have been ignored.

🛡️ **Solution:** Updated `get_ignore_list` in `bakzip/services/directory_processor.py` to accept the target directory as an argument and dynamically construct the path to `.bakzipignore` using `os.path.join(directory, '.bakzipignore')`. Updated the caller `process_directory` to pass the correct directory. Added new tests in `tests/test_get_ignore_list_path.py` to verify that the file is correctly resolved relative to the target directory.

---
*PR created automatically by Jules for task [12339966465574609499](https://jules.google.com/task/12339966465574609499) started by @Smx27*